### PR TITLE
Avoid ServiceContent requirement in lookup.NewClient

### DIFF
--- a/lookup/client.go
+++ b/lookup/client.go
@@ -55,13 +55,15 @@ type Client struct {
 func NewClient(ctx context.Context, c *vim25.Client) (*Client, error) {
 	// PSC may be external, attempt to derive from sts.uri
 	path := &url.URL{Path: Path}
-	m := object.NewOptionManager(c, *c.ServiceContent.Setting)
-	opts, err := m.Query(ctx, "config.vpxd.sso.sts.uri")
-	if err == nil && len(opts) == 1 {
-		u, err := url.Parse(opts[0].GetOptionValue().Value.(string))
-		if err == nil {
-			path.Scheme = u.Scheme
-			path.Host = u.Host
+	if c.ServiceContent.Setting != nil {
+		m := object.NewOptionManager(c, *c.ServiceContent.Setting)
+		opts, err := m.Query(ctx, "config.vpxd.sso.sts.uri")
+		if err == nil && len(opts) == 1 {
+			u, err := url.Parse(opts[0].GetOptionValue().Value.(string))
+			if err == nil {
+				path.Scheme = u.Scheme
+				path.Host = u.Host
+			}
 		}
 	}
 

--- a/lookup/simulator/simulator_test.go
+++ b/lookup/simulator/simulator_test.go
@@ -140,4 +140,10 @@ func TestClient(t *testing.T) {
 			t.Errorf("len=%d", len(info))
 		}
 	}
+
+	vc.Client.ServiceContent.Setting = nil // ensure we don't NPE without this set
+	_, err = lookup.NewClient(ctx, vc.Client)
+	if err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
As of d7430825, lookup.NewClient uses ServiceContent.Setting.
However, there is existing code that creates vim25.Client without
initializing ServiceContent, resulting in a nil pointer dereference.

The use of Setting was only needed for external PSC, make it optional
to avoid the NPE.